### PR TITLE
oreohive.org alpha 0.0.2.1

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -1,5 +1,71 @@
 <!-- src/app.html -->
 
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
+
 <!doctype html>
 <html lang="en">
 <meta charset="UTF-8" />

--- a/web/src/components/FullPageTitle.svelte
+++ b/web/src/components/FullPageTitle.svelte
@@ -64,6 +64,8 @@ we can work on it :))) -->
         padding-left: 8px;
         padding-right: 8px;
         margin: 0px;
+        margin-left: 428px !important;
+        margin-right: 428px !important;
         overflow: hidden;
     }
     h1 {

--- a/web/src/components/FullPageTitle2.svelte
+++ b/web/src/components/FullPageTitle2.svelte
@@ -77,8 +77,8 @@ we can work on it :))) -->
         border-style: solid;
         border-width: 6px;
         border-color: #000;
-        min-width: 25vw;
-        max-width: 100%;
+        min-width: 50vw;
+        max-width: 50vw;
         border-radius: 256px;
         padding: 4px;
         padding-top: 4px;
@@ -86,6 +86,8 @@ we can work on it :))) -->
         padding-left: 8px;
         padding-right: 8px;
         margin: 0px;
+        margin-left: 24px !important;
+        margin-right: 24px !important;
         overflow: hidden;
     }
     h1 {

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/+layout.svelte -->
+<!-- src/routes/+layout.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,4 +1,71 @@
-<!-- src/routes/+layout.svelte -->
+<!-- /src/routes/+layout.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
+
 <script lang="ts">
   import { browser } from '$app/environment';
   import { page, navigating, updated } from '$app/state';

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,4 +1,70 @@
-<!-- src/routes/+page.svelte -->
+<!-- /src/routes/+page.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
 
 <script lang="ts">
     import Panel from "../components/Panel.svelte";

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/+page.svelte -->
+<!-- src/routes/+page.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/activity-log/+layout.svelte
+++ b/web/src/routes/activity-log/+layout.svelte
@@ -1,4 +1,5 @@
 <!-- src/routes/activity-log/+layout.svelte -->
+ 
 <script>
   import TitleDisplay from "$components/TitleDisplay.svelte";
   import KofiDonateMsg from "$components/KofiDonateMsg.svelte";

--- a/web/src/routes/activity-log/+page.svelte
+++ b/web/src/routes/activity-log/+page.svelte
@@ -1,3 +1,71 @@
+<!-- src/routes/activity-log/+page.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
+
 <script lang="ts">
 import Panel from "$components/Panel.svelte";
 export let data;

--- a/web/src/routes/contribute/+page.svelte
+++ b/web/src/routes/contribute/+page.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/contribute/+page.svelte -->
+<!-- src/routes/contribute/+page.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/contribute/+page.svelte
+++ b/web/src/routes/contribute/+page.svelte
@@ -1,3 +1,71 @@
+<!-- /src/routes/contribute/+page.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
+
 <script>
     import FullPageTitle from "$components/FullPageTitle2.svelte";
 </script>

--- a/web/src/routes/edu/+layout.svelte
+++ b/web/src/routes/edu/+layout.svelte
@@ -1,3 +1,71 @@
+<!-- /src/routes/edu/+layout.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
+
 <script>
 </script>
 

--- a/web/src/routes/edu/+layout.svelte
+++ b/web/src/routes/edu/+layout.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/edu/+layout.svelte -->
+<!-- src/routes/edu/+layout.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/error-pages/+layout.svelte
+++ b/web/src/routes/error-pages/+layout.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/error-pages/+layout.svelte -->
+<!-- src/routes/error-pages/+layout.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/error-pages/+layout.svelte
+++ b/web/src/routes/error-pages/+layout.svelte
@@ -1,4 +1,69 @@
-<!-- src/routes/error-pages/404/+layout.svelte -->
+<!-- /src/routes/error-pages/+layout.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
 
 <slot />
-    

--- a/web/src/routes/human/+layout.svelte
+++ b/web/src/routes/human/+layout.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/human/+layout.svelte -->
+<!-- src/routes/human/+layout.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/human/+layout.svelte
+++ b/web/src/routes/human/+layout.svelte
@@ -1,3 +1,71 @@
+<!-- /src/routes/human/+layout.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
+
 <div class="container">
     <div class="centre-container">
         <slot />

--- a/web/src/routes/human/+page.svelte
+++ b/web/src/routes/human/+page.svelte
@@ -1,4 +1,70 @@
-<!-- src/routes/human/+page.svelte -->
+<!-- /src/routes/human/+page.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
 
 <script lang="ts">
   import Panel from "$components/Panel.svelte";

--- a/web/src/routes/human/+page.svelte
+++ b/web/src/routes/human/+page.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/human/+page.svelte -->
+<!-- src/routes/human/+page.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/labs/+layout.svelte
+++ b/web/src/routes/labs/+layout.svelte
@@ -1,3 +1,71 @@
+<!-- /src/routes/labs/+layout.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
+
 <div class="container">
     <slot />
 </div>

--- a/web/src/routes/labs/+layout.svelte
+++ b/web/src/routes/labs/+layout.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/labs/+layout.svelte -->
+<!-- src/routes/labs/+layout.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/labs/+page.svelte
+++ b/web/src/routes/labs/+page.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/labs/+page.svelte -->
+<!-- src/routes/labs/+page.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/library/+page.svelte
+++ b/web/src/routes/library/+page.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/labs/+page.svelte -->
+<!-- src/routes/library/+page.svelte -->
 
 <!--
     ---------- ---------- --
@@ -12,9 +12,9 @@
 
     ---------- ---------- --
     Notably, our Terms & Ethics of Use strictly prohibit the use of our code
-    and writing for the training, improvement, diagnostics or iterations of
+    and writing for the training, improvement, diagnostics or iterations of 
     AI models and machine learning algorithms.
-
+    
     The interpretation of our works (such as this file) by machine learning
     algorithms is not necessarily prohibited. However, to maintain compliance,
     this file should not be used in training or improving ML, AI or their
@@ -48,7 +48,7 @@
     shared, (re)distributed, utilised or applied) by a party, individual,
     organisation or corporation opens it up to legal repercussions at the
     discretion of the oreohive organisation.
-
+    
     It/they may be found liable for any damages deemed to result from these
     practices, or any fine or repercussion for not following the Terms & Ethics
     of Use.
@@ -67,67 +67,14 @@
 -->
 
 <script lang="ts">
-    import FullPageTitle from "$components/FullPageTitle.svelte";
-  import Panel from "$components/Panel.svelte";
-  import PanelBox from "$components/PanelBox.svelte";
-  import TitleDisplay from "$components/TitleDisplay.svelte";
-  import { PrismicRichText } from "@prismicio/svelte";
-  export let data;
+    import { page } from "$app/state";
+    import FullPageTitle2 from "$components/FullPageTitle2.svelte";
+
 </script>
 
-<svelte:head>
-  <title>labs | oreohive.org</title>
-  <meta name="description" content="oreohive labs | perhaps not quite as scientific as it might sound."/>
-</svelte:head>
+<div class="container">
+    <FullPageTitle2 title="oreohive library">
+    </FullPageTitle2>
 
-<FullPageTitle title="oreohive.org | labs" />
 
-<TitleDisplay title="labs articles" />
-
-{#if data.posts && data.posts.length > 0}
-<div style="color: #7f7fbe;">
-  {#each [...data.posts] as post} <!-- ok it seems to not order with date by default, at least not properly, so uhh let's do this ourselves lol (?) -->
-    <div style="display: flex; border-style: dashed; margin-top: 0px; margin-bottom: 32px; border-radius: 12px;">
-      <div style="display: flex; border-radius: 12px; margin: 0px; margin-top: 18px;">
-      <Panel colour="#fcfcff" img_url={post.data.image.url ?? "/logo.webp"} href={`/labs/labs-articles/${post.uid}`}/>
-      <div>
-        <a href={`/labs/labs-articles/${post.uid}`}><h3><PrismicRichText field={post.data.title ?? "a post title"} /></h3></a>
-        <div style="display: flex; margin-left: 16px;">
-        
-        <p>{post.data.timestamp}</p>
-        <PrismicRichText field={post.data.author ?? "an author"}/>
-        </div>
-      </div>
-      </div>
-    </div>
-  {/each}
-</div>
-
-{:else}
-  <p>oops! no posts found. sorry!</p>
-{/if}
-
-<style>
-  * {
-    min-width: fit-content;
-    text-wrap: wrap;
-    flex-wrap: wrap;
-  }
-
-  p {
-    overflow: hidden;
-    max-width: 100%;
-  }
-  .dark p {
-    color: #000000 !important;
-  }
-
-  li {
-    overflow: hidden;
-    max-width: 100%;
-  }
-
-  .dark li {
-    background-color: #5a5467;
-  }
-</style>
+</div> <!-- container -->

--- a/web/src/routes/onboarding/+layout.svelte
+++ b/web/src/routes/onboarding/+layout.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/onboarding/+layout.svelte -->
+<!-- src/routes/onboarding/+layout.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/onboarding/+layout.svelte
+++ b/web/src/routes/onboarding/+layout.svelte
@@ -1,3 +1,71 @@
+<!-- /src/routes/onboarding/+layout.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
+
 <div class="container">
     <div style="max-width: 100vw; margin: 0 auto;">
     <slot />

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -1,3 +1,71 @@
+<!-- /src/routes/onboarding/+page.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
+
 <script>
     import { enhance } from "$app/forms";
     import { browser } from "$app/environment";

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/onboarding/+page.svelte -->
+<!-- src/routes/onboarding/+page.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/sliceydicey/+layout.svelte
+++ b/web/src/routes/sliceydicey/+layout.svelte
@@ -1,3 +1,71 @@
+<!-- /src/routes/sliceydicey/+layout.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
+
 <div class="container" style="min-height: 94vh;">
     <slot />
 </div>

--- a/web/src/routes/sliceydicey/+layout.svelte
+++ b/web/src/routes/sliceydicey/+layout.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/sliceydicey/+layout.svelte -->
+<!-- src/routes/sliceydicey/+layout.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/sliceydicey/+page.svelte
+++ b/web/src/routes/sliceydicey/+page.svelte
@@ -1,4 +1,70 @@
-<!-- src/routes/+page.svelte -->
+<!-- /src/routes/sliceydicey/+page.svelte -->
+
+<!--
+    ---------- ---------- --
+    This file and its (lines of) code are licensed under the GNU AGPL-3.0,
+    unless otherwise officially and explicitly specified by us, the oreohive
+    organisation.
+
+    While we make our source code available to the general public in pursuit
+    of a better internet, not all freedoms granted by our licensing schemes may
+    apply in all circumstances, given our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Notably, our Terms & Ethics of Use strictly prohibit the use of our code
+    and writing for the training, improvement, diagnostics or iterations of
+    AI models and machine learning algorithms.
+
+    The interpretation of our works (such as this file) by machine learning
+    algorithms is not necessarily prohibited. However, to maintain compliance,
+    this file should not be used in training or improving ML, AI or their
+    datasets, or in altering the behaviour of any model at its core.
+
+    ---------- ---------- --
+    For example, a large language model is allowed to process our code, and
+    even remember details about it in a private setting. A text-to-speech model
+    processing our text to simply 'speak it aloud' does not violate our Terms &
+    Ethics of Use. However, training any model with our works is not permitted.
+
+    ---------- ---------- --
+    If a model or algorithm is to 'remember' our works or details about them,
+    it is to have stored, persisted or retrieved user-provided data for the
+    sole purpose of personalising or enhancing individual user sessions,
+    without altering the model's core parameters. This is ALLOWED.
+
+    Updating, adapting or (fine-)tuning a model or algorithm's internal
+    parameters (e.g. weights, biases, architecture) using any of our works
+    (data under the oreohive organisation's Terms & Ethics of Use) or any
+    derivative thereof is classed strictly as having the model TRAINED or
+    IMPROVED with our works, which is NOT ALLOWED by our Terms & Ethics of Use.
+
+    As such, these 'training' or 'improving' practices are NOT PERMITTED
+    without explicit and formalised exceptions issued by the oreohive
+    organisation. These kinds of exceptions and how they might work are
+    detailed in our Terms & Ethics of Use.
+
+    ---------- ---------- --
+    Any breach of our Terms & Ethics of Use (e.g. in how our works are used,
+    shared, (re)distributed, utilised or applied) by a party, individual,
+    organisation or corporation opens it up to legal repercussions at the
+    discretion of the oreohive organisation.
+
+    It/they may be found liable for any damages deemed to result from these
+    practices, or any fine or repercussion for not following the Terms & Ethics
+    of Use.
+
+    The latest publication of our Terms & Ethics of Use should be available at
+    https://oreohive.org/onboarding. If you're struggling to access these Terms
+    & Ethics of Use, please contact us via our official means of communication.
+
+    ---------- ---------- --
+    We appreciate in advance your understanding and cooperation. We hope
+    sincerely that the true potential of developments in machine learning
+    technologies is realised in ways that truly benefit our world and respect
+    the works and livelihoods of artists around the world.
+
+    ---------- ---------- --
+-->
 
 <script lang="ts">
   import Panel from '$components/Panel.svelte';

--- a/web/src/routes/sliceydicey/+page.svelte
+++ b/web/src/routes/sliceydicey/+page.svelte
@@ -1,4 +1,4 @@
-<!-- /src/routes/sliceydicey/+page.svelte -->
+<!-- src/routes/sliceydicey/+page.svelte -->
 
 <!--
     ---------- ---------- --

--- a/web/src/routes/sliceydicey/router-dashboard/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/+page.svelte
@@ -1,8 +1,4 @@
-<script>
-    import FullPageTitle2 from "$components/FullPageTitle2.svelte";
-
-</script>
-<!-- /src/routes/sliceydicey/router-dashboard/+page.svelte -->
+<!-- src/routes/sliceydicey/router-dashboard/+page.svelte -->
 
 <!--
     ---------- ---------- --
@@ -69,6 +65,10 @@
 
     ---------- ---------- --
 -->
+
+<script>
+    import FullPageTitle2 from "$components/FullPageTitle2.svelte";
+</script>
 
 <FullPageTitle2 title="router dashboard">
     <h1 style="margin-right: 24px !important;">

--- a/web/src/routes/sliceydicey/router-dashboard/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/+page.svelte
@@ -1,4 +1,8 @@
-<!-- src/routes/library/+page.svelte -->
+<script>
+    import FullPageTitle2 from "$components/FullPageTitle2.svelte";
+
+</script>
+<!-- /src/routes/sliceydicey/router-dashboard/+page.svelte -->
 
 <!--
     ---------- ---------- --
@@ -12,9 +16,9 @@
 
     ---------- ---------- --
     Notably, our Terms & Ethics of Use strictly prohibit the use of our code
-    and writing for the training, improvement, diagnostics or iterations of 
+    and writing for the training, improvement, diagnostics or iterations of
     AI models and machine learning algorithms.
-    
+
     The interpretation of our works (such as this file) by machine learning
     algorithms is not necessarily prohibited. However, to maintain compliance,
     this file should not be used in training or improving ML, AI or their
@@ -48,7 +52,7 @@
     shared, (re)distributed, utilised or applied) by a party, individual,
     organisation or corporation opens it up to legal repercussions at the
     discretion of the oreohive organisation.
-    
+
     It/they may be found liable for any damages deemed to result from these
     practices, or any fine or repercussion for not following the Terms & Ethics
     of Use.
@@ -66,14 +70,92 @@
     ---------- ---------- --
 -->
 
-<script lang="ts">
-    import { page } from "$app/state";
-    import FullPageTitle2 from "$components/FullPageTitle2.svelte";
+<FullPageTitle2 title="router dashboard">
+    <h1 style="margin-right: 24px !important;">
+        Please select your brand of your router from below:
+    </h1>
+</FullPageTitle2>
 
-</script>
+<h1>To access the dashboard of your router, you may try the following IP addresses:</h1>
+<p><i>Enter these in your browser's address bar.</i></p>
 
-<div class="container">
-    <FullPageTitle2 title="oreohive library">
-    </FullPageTitle2>
+<ol>
+    <li><a href="192.168.0.1">192.168.0.1</a></li>
+    <li><a href="192.168.1.1">192.168.1.1</a></li>
 
-</div> <!-- container -->
+    <li><a href="10.0.0.1">10.0.0.1</a></li>
+    <li><a href="10.0.0.2">10.0.0.2</a></li>
+
+    <li><a href="192.168.0.100">192.168.0.100</a></li>
+    <li><a href="192.168.1.100">192.168.1.100</a></li>
+
+    <li><a href="192.168.0.254">192.168.0.254</a></li>
+    <li><a href="192.168.1.254">192.168.1.254</a></li>
+    <li><a href="192.168.254.254">192.168.254.254</a></li>
+
+    <li><a href="10.10.1.1">10.10.1.1</a></li>
+    <li><a href="10.1.1.1">10.1.1.1</a></li>
+
+    <li><a href="192.168.3.1">192.168.3.1"</li>
+    <li><a href="192.168.8.1">192.168.8.1"</li>
+    <li><a href="192.168.16.1">192.168.16.1</a></li>
+    <li><a href="192.168.0.50">192.168.0.50</a></li>
+    <li><a href="192.168.11.1">192.168.11.1</a></li>
+    <li><a href="192.168.1.99">192.168.1.99</a></li>
+</ol>
+
+<!-- wip
+<ol>
+    <li>2Wire</li>
+    <li>3Com</li>
+    <li>Actiontec</li>
+    <li>Airlink</li>
+    <li>Airlive</li>
+    <li>Airties</li>
+    <li>Apple</li>
+    <li>Amped Wireless</li>
+    <li>ASUS</li>
+    <li>Aztech</li>
+    <li>Belkin</li>
+    <li>Billion</li>
+    <li>Buffalo</li>
+    <li>Dell</li>
+    <li>Cisco</li>
+    <li>D-Link</li>
+    <li>Edimax</li>
+    <li>Eminent</li>
+    <li>Gigabyte</li>
+    <li>Hawking</li>
+    <li>Huawei</li>
+    <li>LevelOne</li>
+    <li>Linksys</li>
+    <li>Microsoft</li>
+    <li>Motorola</li>
+    <li>MSI</li>
+    <li>Netgear</li>
+    <li>NetComm</li>
+    <li>Netopia</li>
+    <li>Planet</li>
+    <li>Plusnet</li>
+    <li>Repotec</li>
+    <li>Sagemcom</li>
+    <li>Senao</li>
+    <li>Siemens</li>
+    <li>Sitecom</li>
+    <li>Sky</li>
+    <li>SMC Networks</li>
+    <li>Sonicwall</li>
+    <li>SpeedTouch</li>
+    <li>Sweex</li>
+    <li>TalkTalk</li>
+    <li>Tenda</li>
+    <li>Thomson</li>
+    <li>TP-Link</li>
+    <li>Trendnet</li>
+    <li>U.S. Robotics</li>
+    <li>Virgin Media</li>
+    <li>Zoom</li>
+    <li>ZTE</li>
+    <li>Zyxel</li>
+</ol>
+-->

--- a/web/src/routes/sliceydicey/router-dashboard/brands/2wire/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/2wire/+page.svelte
@@ -1,0 +1,20 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>2Wire</title>
+    </svelte:head>
+
+    <body>
+        <h1>2Wire</h1>
+        <p>Try the following IP addresses:</p>
+        <ul>
+            <li><a href="192.168.1.1">192.168.1.1</a></li>
+            <li><a href="192.168.0.1">192.168.0.1</a></li>
+            <li><a href="192.168.1.254">192.168.1.254</a></li>
+            <li><a href="10.0.0.138">10.0.0.138</a></li>
+        </ul>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/3com/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/3com/+page.svelte
@@ -1,0 +1,18 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>3Com</title>
+    </svelte:head>
+
+    <body>
+        <h1>3Com</h1>
+        <p>Try the following IP addresses:</p>
+        <ul>
+            <li><a href="192.168.1.1">192.168.1.1</a></li>
+            <li><a href="192.168.0.1.10.1">192.168.1.10.1</a></li>
+        </ul>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/actiontec/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/actiontec/+page.svelte
@@ -1,0 +1,20 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Actiontec</title>
+    </svelte:head>
+
+    <body>
+        <h1>Actiontec</h1>
+        <p>Try the following IP addresses:</p>
+        <ul>
+            <li><a href="192.168.1.1">192.168.1.1</a></li>
+            <li><a href="192.168.0.1">192.168.0.1</a></li>
+            <li><a href="192.168.2.1">192.168.2.1</a></li>
+            <li><a href="192.168.254.254">192.168.254.254</a></li>
+        </ul>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/airlink/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/airlink/+page.svelte
@@ -1,0 +1,18 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Airlink</title>
+    </svelte:head>
+
+    <body>
+        <h1>Airlink</h1>
+        <p>Try the following IP addresses:</p>
+        <ul>
+            <li><a href="192.168.1.1">192.168.1.1</a></li>
+            <li><a href="192.168.2.1">192.168.2.1</a></li>
+        </ul>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/airlive/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/airlive/+page.svelte
@@ -1,0 +1,17 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Airlive</title>
+    </svelte:head>
+
+    <body>
+        <h1>Airlive</h1>
+        <p>Try the following IP addresses:</p>
+        <ul>
+            <li><a href="192.168.2.1">192.168.2.1</a></li>
+        </ul>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/airties/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/airties/+page.svelte
@@ -1,0 +1,17 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Airties</title>
+    </svelte:head>
+
+    <body>
+        <h1>Airties</h1>
+        <p>Try the following IP addresses:</p>
+        <ul>
+            <li><a href="192.168.2.1">192.168.2.1</a></li>
+        </ul>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/amped-wireless/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/amped-wireless/+page.svelte
@@ -1,0 +1,17 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Amped Wireless</title>
+    </svelte:head>
+
+    <body>
+        <h1>Amped Wireless</h1>
+        <p>Try the following IP addresses:</p>
+        <ul>
+            <li><a href="192.168.3.1">192.168.3.1</a></li>
+        </ul>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/apple/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/apple/+page.svelte
@@ -1,0 +1,18 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Apple</title>
+    </svelte:head>
+
+    <body>
+        <h1>Apple</h1>
+        <p>Try the following IP addresses:</p>
+        <ul>
+            <li><a href="10.0.1.1">10.0.0.1S
+            </a></li>
+        </ul>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/asus/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/asus/+page.svelte
@@ -1,0 +1,19 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>ASUS</title>
+    </svelte:head>
+
+    <body>
+        <h1>ASUS</h1>
+        <p>Try the following IP addresses:</p>
+        <ul>
+            <li><a href="192.168.1.1">192.168.1.1</a></li>
+            <li><a href="192.168.2.1">192.168.2.1</a></li>
+            <li><a href="10.10.1.1">10.10.1.1</a></li>
+        </ul>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/aztech/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/aztech/+page.svelte
@@ -1,0 +1,20 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Aztech</title>
+    </svelte:head>
+
+    <body>
+        <h1>Aztech</h1>
+        <p>Try the following IP addresses:</p>
+        <ul>
+            <li><a href="192.168.1.1">192.168.1.1</a></li>
+            <li><a href="192.168.2.1">192.168.2.1</a></li>
+            <li><a href="192.168.1.254">192.186.1.254</a></li>
+            <li><a href="192.168.254.254">192.186.254.254</a></li>
+        </ul>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/belkin/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/belkin/+page.svelte
@@ -1,0 +1,19 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Belkin</title>
+    </svelte:head>
+
+    <body>
+        <h1>Belkin</h1>
+        <ul>
+            <li><a href="192.168.1.1">192.168.1.1</a></li>
+            <li><a href="192.168.2.1">192.168.2.1</a></li>
+            <li><a href="10.0.0.2">10.0.0.2</a></li>
+            <li><a href="10.1.1.1">10.1.1.1</a></li>
+        </ul>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/billion/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/billion/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Billion</title>
+    </svelte:head>
+
+    <body>
+        <h1>Billion</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/buffalo/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/buffalo/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Buffalo</title>
+    </svelte:head>
+
+    <body>
+        <h1>Buffalo</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/cisco/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/cisco/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Cisco</title>
+    </svelte:head>
+
+    <body>
+        <h1>Cisco</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/d-link/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/d-link/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>D-Link</title>
+    </svelte:head>
+
+    <body>
+        <h1>D-Link</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/dell/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/dell/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Dell</title>
+    </svelte:head>
+
+    <body>
+        <h1>Dell</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/edimax/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/edimax/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Edimax</title>
+    </svelte:head>
+
+    <body>
+        <h1>Edimax</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/eminent/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/eminent/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Eminent</title>
+    </svelte:head>
+
+    <body>
+        <h1>Eminent</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/gigabyte/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/gigabyte/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Gigabyte</title>
+    </svelte:head>
+
+    <body>
+        <h1>Gigabyte</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/hawking/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/hawking/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Hawking</title>
+    </svelte:head>
+
+    <body>
+        <h1>Hawking</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/huawei/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/huawei/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Huawei</title>
+    </svelte:head>
+
+    <body>
+        <h1>Huawei</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/levelone/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/levelone/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>LevelOne</title>
+    </svelte:head>
+
+    <body>
+        <h1>LevelOne</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/linksys/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/linksys/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Linksys</title>
+    </svelte:head>
+
+    <body>
+        <h1>Linksys</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/microsoft/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/microsoft/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Microsoft</title>
+    </svelte:head>
+
+    <body>
+        <h1>Microsoft</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/motorola/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/motorola/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Motorola</title>
+    </svelte:head>
+
+    <body>
+        <h1>Motorola</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/msi/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/msi/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>MSI</title>
+    </svelte:head>
+
+    <body>
+        <h1>MSI</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/netcomm/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/netcomm/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>NetComm</title>
+    </svelte:head>
+
+    <body>
+        <h1>NetComm</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/netgear/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/netgear/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Netgear</title>
+    </svelte:head>
+
+    <body>
+        <h1>Netgear</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/netopia/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/netopia/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Netopia</title>
+    </svelte:head>
+
+    <body>
+        <h1>Netopia</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/planet/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/planet/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Planet</title>
+    </svelte:head>
+
+    <body>
+        <h1>Planet</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/plusnet/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/plusnet/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Plusnet</title>
+    </svelte:head>
+
+    <body>
+        <h1>Plusnet</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/repotec/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/repotec/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Repotec</title>
+    </svelte:head>
+
+    <body>
+        <h1>Repotec</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/sagemcom/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/sagemcom/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Sagemcom</title>
+    </svelte:head>
+
+    <body>
+        <h1>Sagemcom</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/senao/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/senao/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Senao</title>
+    </svelte:head>
+
+    <body>
+        <h1>Senao</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/siemens/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/siemens/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Siemens</title>
+    </svelte:head>
+
+    <body>
+        <h1>Siemens</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/sitecom/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/sitecom/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Sitecom</title>
+    </svelte:head>
+
+    <body>
+        <h1>Sitecom</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/sky/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/sky/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Sky</title>
+    </svelte:head>
+
+    <body>
+        <h1>Sky</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/smc-networks/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/smc-networks/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>SMC Networks</title>
+    </svelte:head>
+
+    <body>
+        <h1>SMC Networks</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/sonicwall/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/sonicwall/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Sonicwall</title>
+    </svelte:head>
+
+    <body>
+        <h1>Sonicwall</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/speedtouch/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/speedtouch/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>SpeedTouch</title>
+    </svelte:head>
+
+    <body>
+        <h1>SpeedTouch</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/sweex/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/sweex/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Sweex</title>
+    </svelte:head>
+
+    <body>
+        <h1>Sweex</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/talktalk/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/talktalk/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>TalkTalk</title>
+    </svelte:head>
+
+    <body>
+        <h1>TalkTalk</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/tenda/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/tenda/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Tenda</title>
+    </svelte:head>
+
+    <body>
+        <h1>Tenda</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/thomson/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/thomson/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Thomson</title>
+    </svelte:head>
+
+    <body>
+        <h1>Thomson</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/tp-link/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/tp-link/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>TP-Link</title>
+    </svelte:head>
+
+    <body>
+        <h1>TP-Link</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/trendnet/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/trendnet/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Trendnet</title>
+    </svelte:head>
+
+    <body>
+        <h1>Trendnet</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/u-s-robotics/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/u-s-robotics/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>U.S. Robotics</title>
+    </svelte:head>
+
+    <body>
+        <h1>U.S. Robotics</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/virgin-media/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/virgin-media/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Virgin Media</title>
+    </svelte:head>
+
+    <body>
+        <h1>Virgin Media</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/zoom/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/zoom/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Zoom</title>
+    </svelte:head>
+
+    <body>
+        <h1>Zoom</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/zte/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/zte/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>ZTE</title>
+    </svelte:head>
+
+    <body>
+        <h1>ZTE</h1>
+    </body>

--- a/web/src/routes/sliceydicey/router-dashboard/brands/zyxel/+page.svelte
+++ b/web/src/routes/sliceydicey/router-dashboard/brands/zyxel/+page.svelte
@@ -1,0 +1,13 @@
+
+    <script lang="ts">
+        export const prerender = true
+        export let data: any
+    </script>
+
+    <svelte:head>
+        <title>Zyxel</title>
+    </svelte:head>
+
+    <body>
+        <h1>Zyxel</h1>
+    </body>


### PR DESCRIPTION
# oreohive.org alpha 0.0.2.1
the first hotfix since the second phase of our first alpha release, alpha 0!
remember, the second number corresponds to our alpha level, so currently, we're at alpha 0.

## changes
little to no functional changes. however, i have added more transparent licensing disclaimers to some of our files, most notably the app.html just now, so the likes of crawlers may see it.

i look forward to making more such changes soon to improve our seo, and improve our site's digestability for harmless crawlers like those used for google search!
we aim to continue to prohibit the access of our content, resources, materials and works for the purposes of ml training, so will act accordingly.

thanks all!